### PR TITLE
megaglest.profile: Add allow-lua.inc

### DIFF
--- a/etc/profile-m-z/megaglest.profile
+++ b/etc/profile-m-z/megaglest.profile
@@ -8,6 +8,8 @@ include globals.local
 
 noblacklist ${HOME}/.megaglest
 
+include allow-lua.inc
+
 include disable-common.inc
 include disable-devel.inc
 include disable-exec.inc
@@ -19,7 +21,7 @@ include disable-xdg.inc
 mkdir ${HOME}/.megaglest
 whitelist ${HOME}/.megaglest
 whitelist /usr/share/megaglest
-whitelist /usr/share/games/megaglest	# Debian version
+whitelist /usr/share/games/megaglest # Debian version
 include whitelist-common.inc
 include whitelist-runuser-common.inc
 include whitelist-usr-share-common.inc


### PR DESCRIPTION
Would not start otherwise. It would report:

```
megaglest: error while loading shared libraries: liblua5.1.so.5.1: cannot open shared object file: Permission denied
```